### PR TITLE
Add coverage report uploading

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,5 +33,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install git+https://github.com/AstarVienna/ScopeSim_Data.git
           pip install .[test]
+          pip install pytest pytest-cov
       - name: Run Pytest
-        run: pytest
+        run: pytest --cov
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
We have a codecov project for (almost) all of our projects, so we should upload coverage for all of them.

I'll make a codecov project for those project that do not yet have one.
