### PR TITLE
Use linkspector

### DIFF
--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -17,8 +17,11 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get install npm
+        # See https://github.com/UmbrellaDocs/linkspector
         npm install -g @umbrelladocs/linkspector
     - name: Check links
       run: |
-        printf "dirs:\n  - ./\n" > .linkspector.yml
+        # Generate default configuration file if it doesn't exist.
+        if [ ! -f .linkspector.yml ] ; then printf "dirs:\n  - ./\n" > .linkspector.yml ; fi
+        # Run the check.
         linkspector check

--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -2,6 +2,12 @@ name: Check Markdown links
 
 on:
   push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
   schedule:
     - # Run every day at 5:00 UTC
     - cron: "0 5 * * *"

--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -14,4 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - name: Install dependencies
+      run: |
+        apt-get install npm
+        npm install -g @umbrelladocs/linkspector
+    - name: Check links
+      run: |
+        printf "dirs:\n  - ./\n" > .linkspector.yml
+        linkspector check

--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -1,4 +1,5 @@
 name: Check Markdown links
+# See https://github.com/UmbrellaDocs/linkspector
 
 on:
   push:
@@ -23,11 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - uses: actions/setup-node@v4
     - name: Install dependencies
-      run: |
-        apt-get install npm
-        # See https://github.com/UmbrellaDocs/linkspector
-        npm install -g @umbrelladocs/linkspector
+      run: npm install -g @umbrelladocs/linkspector
     - name: Check links
       run: |
         # Generate default configuration file if it doesn't exist.

--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+  # Allows you to run this workflow manually from the Actions tab.
+  workflow_dispatch:
+
   schedule:
     - # Run every day at 5:00 UTC
     - cron: "0 5 * * *"

--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ These quotes highlight the goal and status of this repository.
 [arghwhat](https://news.ycombinator.com/item?id=36354464)
 
 > The problem with DevOps is not really how it is practiced, but how it is named. DevOps is a bucket that a bunch of things are thrown into, and everybody thinks the thing they threw in is DevOps with the others being mislabelled.
+
+## Testing links
+
+This link is valid, but cannot be validated with markdown-link-checker, but
+can be validated with linkspector: https://doi.org/10.1117/12.2559784


### PR DESCRIPTION
Use linkspector instead of markdown-link-check

markdown-link-check does not work with the new redirection scheme of SPIE, see https://github.com/AstarVienna/ScopeSim/issues/322

The creator the github action we used to use, states that we should move to linkspector: https://github.com/gaurav-nelson/github-action-markdown-link-check

See #10 to see how the action looks for a broken link.
