### PR TITLE
Test 3.12 but not 3.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']#, '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Ideally, this could be changed by the calling workflow. But we're in the process of dropping 3.8 in favor of 3.12 in some projects and they're failing because this is still here...