### PR TITLE
Split webtests into separate workflow

### DIFF
--- a/.github/workflows/webtests.yml
+++ b/.github/workflows/webtests.yml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   run-tests:
+    # The web tests are run with a limited matrix, because they retrieve data
+    #  from the internet and therefor run into rate limits with the full matrix.
     name: Run tests
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/webtests.yml
+++ b/.github/workflows/webtests.yml
@@ -16,12 +16,11 @@ on:
 jobs:
   run-tests:
     name: Run tests
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.12']
 
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +41,7 @@ jobs:
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
 
       - name: Run Pytest
-        run: poetry run pytest -m "not webtest" --cov --cov-report=xml
+        run: poetry run pytest -m "webtest" --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
Ideally this would be done less repetitive with a general workflow that has arguments, but with the reduced matrix for the webtests, it's simpler for now to just have two separate ones...

Codecov should be intelligent enough to merge the coverage from both tests, let's see...