### PR TITLE
Dynamic job name

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   run-tests:
-    name: Run tests
+    name: ${{ matrix.os }}, ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
This reduces the long name of the matrix tests (see https://github.com/AstarVienna/DevOps/actions/runs/7541027577).

The "Run tests" name didn't add any useful information anyway...