### PR TITLE
Drop Python 3.8 from test matrix

### DIFF
--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           # Keep python-version on the lowest version from pyproject.toml.
           # Also update the regexp below.
-          python-version: 3.8
+          python-version: 3.9
       - name: Install dependencies
         run: |
           # Hardcode the minimum version of the dependencies.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Some of our projects still use these non-poetry based workflows, but have (internal) dependencies which require Python 3.9 at least, so it's no longer possible to include 3.8 here.