### PR TITLE
Update github action versions

### DIFF
--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -23,8 +23,10 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
+      with:
+        node-version: 20
     - name: Install dependencies
       run: npm install -g @umbrelladocs/linkspector
     - name: Check links

--- a/.github/workflows/minimumdependencies.yml
+++ b/.github/workflows/minimumdependencies.yml
@@ -30,9 +30,9 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           # Keep python-version on the lowest version from pyproject.toml.
           # Also update the regexp below.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,9 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -44,4 +44,6 @@ jobs:
       - name: Run Pytest
         run: pytest --cov
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- actions/setup-python@v5 updates node version from node16 to node20
- actions/checkout@v4 seems to be the standard
- actions/setup-node@v4 recommends specifying a node version

This change is prompted by github complaining that "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4, codecov/codecov-action@v3." E.g: https://github.com/AstarVienna/ScopeSim/actions/runs/9057582692

However, setup-python@v4 still uses node 16 apparently, so v5 is needed. Codecov-action has a v4 but that has breaking changes, so I did not want to upgrade that, as it did not seem necessary.