### PR TITLE
Update github action versions

### DIFF
--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -1,4 +1,5 @@
 name: Check Markdown links
+# See https://github.com/UmbrellaDocs/linkspector
 
 on:
   push:
@@ -13,5 +14,15 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+    - name: Install dependencies
+      run: npm install -g @umbrelladocs/linkspector
+    - name: Check links
+      run: |
+        # Generate default configuration file if it doesn't exist.
+        if [ ! -f .linkspector.yml ] ; then printf "dirs:\n  - ./\n" > .linkspector.yml ; fi
+        # Run the check.
+        linkspector check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -45,6 +45,6 @@ jobs:
         run: poetry run pytest -m "not webtest" --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- actions/setup-python@v5 updates node version from node16 to node20
- actions/checkout@v4 seems to be the standard
- actions/setup-node@v4 recommends specifying a node version
- codecov-action to v4

This change is prompted by github complaining that "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-python@v4, codecov/codecov-action@v3."

The new codecov action requires the use of CODECOV_TOKEN