### PR TITLE
Make use of Poetry parametrized

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,17 +44,36 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
+        if: inputs.poetry
         uses: abatilo/actions-poetry@v2
         with:
           poetry-version: "1.7.1"
 
-      - name: Install dependencies
+      - name: Install dependencies with Poetry
+        if: inputs.poetry
         run: |
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
 
+      - name: Install dependencies without Poetry
+        if: ${{ ! inputs.poetry }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install git+https://github.com/AstarVienna/ScopeSim_Data.git
+          # Install this clone of the project. This is relevant because for
+          # example ScopeSim has ScopeSim_Templates as a test-dependency
+          # and that package has ScopeSim as a dependency. So the PyPI version
+          # of ScopeSim would be installed without the "pip install ." line.
+          pip install .
+          # TODO: It should not be necessary to install the dev dependencies.
+          #       Perhaps create a separate test for that?
+          pip install .[test,dev]
+          pip install pytest pytest-cov
+
       - name: Run Pytest
-        run: poetry run pytest -m "not webtest" --cov --cov-report=xml
+        env:
+          PTRY: ${{ inputs.poetry && 'poetry run' || '' }}
+        run: $PTRY pytest -m "not webtest" --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,9 +45,9 @@ jobs:
 
       - name: Set up Poetry
         if: inputs.poetry
-        uses: abatilo/actions-poetry@v2
+        uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: "1.7.1"
+          poetry-version: "1.8.3"
 
       - name: Install dependencies with Poetry
         if: inputs.poetry

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - master
       - main
+      - poetry
   pull_request:
     branches:
       - master
       - main
+      - poetry
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,19 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      poetry:
+        type: boolean
+        description: "Use Poetry-based workflow."
+        required: false
 
   # Allow this workflow to be called from other repositories.
   workflow_call:
+    inputs:
+      poetry:
+        type: boolean
+        description: "Use Poetry-based workflow."
+        required: false
 
 jobs:
   run-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,10 @@ jobs:
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
 
+      - name: Run Pytest with Poetry
+        if: inputs.poetry
+        run: poetry run pytest -m "not webtest" --cov --cov-report=xml
+
       - name: Install dependencies without Poetry
         if: ${{ ! inputs.poetry }}
         run: |
@@ -70,10 +74,9 @@ jobs:
           pip install .[test,dev]
           pip install pytest pytest-cov
 
-      - name: Run Pytest
-        env:
-          PTRY: ${{ inputs.poetry && 'poetry run' || '' }}
-        run: $PTRY pytest -m "not webtest" --cov --cov-report=xml
+      - name: Run Pytest without Poetry
+        if: ${{ ! inputs.poetry }}
+        run: pytest -m "not webtest" --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,23 +44,23 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
-        if: inputs.poetry
+        if: ${{ inputs.poetry || github.event_name == 'push' || github.event_name == 'pull_request' }}
         uses: abatilo/actions-poetry@v3
         with:
           poetry-version: "1.8.3"
 
       - name: Install dependencies with Poetry
-        if: inputs.poetry
+        if: ${{ inputs.poetry || github.event_name == 'push' || github.event_name == 'pull_request' }}
         run: |
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
 
       - name: Run Pytest with Poetry
-        if: inputs.poetry
+        if: ${{ inputs.poetry || github.event_name == 'push' || github.event_name == 'pull_request' }}
         run: poetry run pytest -m "not webtest" --cov --cov-report=xml
 
       - name: Install dependencies without Poetry
-        if: ${{ ! inputs.poetry }}
+        if: ${{ ! inputs.poetry && github.event_name != 'push' && github.event_name != 'pull_request' }}
         run: |
           python -m pip install --upgrade pip
           pip install git+https://github.com/AstarVienna/ScopeSim_Data.git
@@ -75,7 +75,7 @@ jobs:
           pip install pytest pytest-cov
 
       - name: Run Pytest without Poetry
-        if: ${{ ! inputs.poetry }}
+        if: ${{ ! inputs.poetry && github.event_name != 'push' && github.event_name != 'pull_request' }}
         run: pytest -m "not webtest" --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
     branches:
       - master
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/updated_tests.yml
+++ b/.github/workflows/updated_tests.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - master
       - main
+      - poetry
   pull_request:
     branches:
       - master
       - main
+      - poetry
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/updated_tests.yml
+++ b/.github/workflows/updated_tests.yml
@@ -15,6 +15,8 @@ on:
   # Allow this workflow to be called from other repositories.
   workflow_call:
 
+# This workflow need Poetry, so no flag is included.
+
 jobs:
   run-tests:
     name: ${{ matrix.os }}, ${{ matrix.python-version }}

--- a/.github/workflows/updated_tests.yml
+++ b/.github/workflows/updated_tests.yml
@@ -34,9 +34,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
-        uses: abatilo/actions-poetry@v2
+        uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: "1.7.1"
+          poetry-version: "1.8.3"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/updated_tests.yml
+++ b/.github/workflows/updated_tests.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
     branches:
       - master
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/updated_tests.yml
+++ b/.github/workflows/updated_tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/webtests.yml
+++ b/.github/workflows/webtests.yml
@@ -1,16 +1,5 @@
 name: Tests
 on:
-  push:
-    branches:
-      - master
-      - main
-      - poetry
-  pull_request:
-    branches:
-      - master
-      - main
-      - poetry
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:
@@ -47,23 +36,23 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
-        if: ${{ inputs.poetry || github.event_name == 'push' || github.event_name == 'pull_request' }}
+        if: inputs.poetry
         uses: abatilo/actions-poetry@v3
         with:
           poetry-version: "1.8.3"
 
       - name: Install dependencies with Poetry
-        if: ${{ inputs.poetry || github.event_name == 'push' || github.event_name == 'pull_request' }}
+        if: inputs.poetry
         run: |
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
 
       - name: Run Pytest with Poetry
-        if: ${{ inputs.poetry || github.event_name == 'push' || github.event_name == 'pull_request' }}
+        if: inputs.poetry
         run: poetry run pytest -m "webtest" --cov --cov-report=xml
 
       - name: Install dependencies without Poetry
-        if: ${{ ! inputs.poetry && github.event_name != 'push' && github.event_name != 'pull_request' }}
+        if: ${{ ! inputs.poetry }}
         run: |
           python -m pip install --upgrade pip
           pip install git+https://github.com/AstarVienna/ScopeSim_Data.git
@@ -78,7 +67,7 @@ jobs:
           pip install pytest pytest-cov
 
       - name: Run Pytest without Poetry
-        if: ${{ ! inputs.poetry && github.event_name != 'push' && github.event_name != 'pull_request' }}
+        if: ${{ ! inputs.poetry }}
         run: pytest -m "webtest" --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/webtests.yml
+++ b/.github/workflows/webtests.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - master
       - main
+      - poetry
   pull_request:
     branches:
       - master
       - main
+      - poetry
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/webtests.yml
+++ b/.github/workflows/webtests.yml
@@ -45,23 +45,23 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
-        if: inputs.poetry
+        if: ${{ inputs.poetry || github.event_name == 'push' || github.event_name == 'pull_request' }}
         uses: abatilo/actions-poetry@v3
         with:
           poetry-version: "1.8.3"
 
       - name: Install dependencies with Poetry
-        if: inputs.poetry
+        if: ${{ inputs.poetry || github.event_name == 'push' || github.event_name == 'pull_request' }}
         run: |
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
 
       - name: Run Pytest with Poetry
-        if: inputs.poetry
+        if: ${{ inputs.poetry || github.event_name == 'push' || github.event_name == 'pull_request' }}
         run: poetry run pytest -m "webtest" --cov --cov-report=xml
 
       - name: Install dependencies without Poetry
-        if: ${{ ! inputs.poetry }}
+        if: ${{ ! inputs.poetry && github.event_name != 'push' && github.event_name != 'pull_request' }}
         run: |
           python -m pip install --upgrade pip
           pip install git+https://github.com/AstarVienna/ScopeSim_Data.git
@@ -76,7 +76,7 @@ jobs:
           pip install pytest pytest-cov
 
       - name: Run Pytest without Poetry
-        if: ${{ ! inputs.poetry }}
+        if: ${{ ! inputs.poetry && github.event_name != 'push' && github.event_name != 'pull_request' }}
         run: pytest -m "webtest" --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/webtests.yml
+++ b/.github/workflows/webtests.yml
@@ -11,9 +11,19 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      poetry:
+        type: boolean
+        description: "Use Poetry-based workflow."
+        required: false
 
   # Allow this workflow to be called from other repositories.
   workflow_call:
+    inputs:
+      poetry:
+        type: boolean
+        description: "Use Poetry-based workflow."
+        required: false
 
 jobs:
   run-tests:
@@ -35,19 +45,41 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
+        if: inputs.poetry
         uses: abatilo/actions-poetry@v3
         with:
           poetry-version: "1.8.3"
 
-      - name: Install dependencies
+      - name: Install dependencies with Poetry
+        if: inputs.poetry
         run: |
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
 
-      - name: Run Pytest
+      - name: Run Pytest with Poetry
+        if: inputs.poetry
         run: poetry run pytest -m "webtest" --cov --cov-report=xml
 
+      - name: Install dependencies without Poetry
+        if: ${{ ! inputs.poetry }}
+        run: |
+          python -m pip install --upgrade pip
+          pip install git+https://github.com/AstarVienna/ScopeSim_Data.git
+          # Install this clone of the project. This is relevant because for
+          # example ScopeSim has ScopeSim_Templates as a test-dependency
+          # and that package has ScopeSim as a dependency. So the PyPI version
+          # of ScopeSim would be installed without the "pip install ." line.
+          pip install .
+          # TODO: It should not be necessary to install the dev dependencies.
+          #       Perhaps create a separate test for that?
+          pip install .[test,dev]
+          pip install pytest pytest-cov
+
+      - name: Run Pytest without Poetry
+        if: ${{ ! inputs.poetry }}
+        run: pytest -m "webtest" --cov --cov-report=xml
+
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/webtests.yml
+++ b/.github/workflows/webtests.yml
@@ -35,9 +35,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
-        uses: abatilo/actions-poetry@v2
+        uses: abatilo/actions-poetry@v3
         with:
-          poetry-version: "1.7.1"
+          poetry-version: "1.8.3"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/webtests.yml
+++ b/.github/workflows/webtests.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/webtests.yml
+++ b/.github/workflows/webtests.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
     branches:
       - master
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The current "solution" of dealing with repos that use Poetry and also those that don't using two separate branches is not ideal. As we recently saw, any changes to the workflow in general have to be applied to both branches, which is cumbersome. I tried to let the workflow automatically decide which one to use based on the custom repo property that I included in most of our repos some time ago and has a Poetry flag. However, these (rather new in GH) properties are not directly accessible from the workflow, and getting them via the GH API and some creative JSON juggling might be doable but feels super hacky. Rather than that, I decided the best approach would be to add an optional parameter as a Poetry flag. This way, we can use the same workflow for all repos and simply pass a parameter if Poetry should be used.

To allow this change to be possible without breaking anything, I see two options:

1. Merge this into the `poetry` branch and make the flag True by default, that way any repos currently using this on the poetry branch without any parameter will get the same behavior as before. Any non-poetry repos are unaffected, but can be slowly switched over to using the `poetry` branch with the flag set to False (which is somewhat confusing, "use poetry but actually don't", oh well).
2. Call this branch `main` and don't merge it anywhere (which would mean closing the PR), and leave the flag to default to False (or not, doesn't actually make a functional difference in this case, as no current workflows would get there without manually changing the branch). Once all non-poetry repos are switched over to using this version as described in 1., the new `main` branch can be set as the default branch, and the old `master` discontinued. Similarly, once all poetry-based repos are using the new `main` branch with the flag True, we can discontinue the current `poetry` branch.

Which option do you prefer @hugobuddel ?