### PR TITLE
Try to use tee to pipe to $GITHUB_STEP_SUMMARY

### DIFF
--- a/.github/workflows/updated_tests.yml
+++ b/.github/workflows/updated_tests.yml
@@ -44,7 +44,7 @@ jobs:
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
 
       - name: Update dependencies
-        run: poetry update >> $GITHUB_STEP_SUMMARY
+        run: poetry update | tee -a $GITHUB_STEP_SUMMARY
 
       - name: Run Pytest
         run: poetry run pytest -m "not webtest" --cov --cov-report=xml

--- a/.github/workflows/updated_tests.yml
+++ b/.github/workflows/updated_tests.yml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Summary
+        run: Set-Variable -Name "GITHUB_STEP_SUMMARY" -Value $env:GITHUB_STEP_SUMMARY
+        if: matrix.os == 'windows-latest'
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/updated_tests.yml
+++ b/.github/workflows/updated_tests.yml
@@ -28,10 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Summary
-        run: Set-Variable -Name "GITHUB_STEP_SUMMARY" -Value $env:GITHUB_STEP_SUMMARY
-        if: matrix.os == 'windows-latest'
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -43,12 +39,15 @@ jobs:
           poetry-version: "1.8.3"
 
       - name: Install dependencies
+        shell: bash
         run: |
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
 
       - name: Update dependencies
+        shell: bash
         run: poetry update | tee -a $GITHUB_STEP_SUMMARY
 
       - name: Run Pytest
+        shell: bash
         run: poetry run pytest -m "not webtest" --cov --cov-report=xml


### PR DESCRIPTION
This should ensure the information is both available in the summary as well as in the logs.

E.g. in https://github.com/AstarVienna/ScopeSim/actions/runs/11007444291/job/30563361651 it is hard to figure out what version of fonttools is actually being used.

`>>` schmekt ein bißchen (aber eben nicht ganz) anders als Tee