### PR TITLE
Run doctests without webtests and slow tests

### DIFF
--- a/.github/workflows/docstring_tests.yml
+++ b/.github/workflows/docstring_tests.yml
@@ -38,4 +38,4 @@ jobs:
 
       - name: Run Pytest
         shell: bash
-        run: poetry run pytest --doctest-modules --cov --cov-report=xml
+        run: poetry run pytest -m "not webtest and not slow" --doctest-modules --cov --cov-report=xml


### PR DESCRIPTION
Running the doctests seems to also run all the normal tests as well. After a quick search, it seems there's no non-hacky way to disable that. Since we already have the "normal" test workflows for all of those, I propose to exclude at least the sometimes costly webtest from the doctests run. If I understand correctly, this should still run all doctests for classes and functions that are otherwise tested with webtests, because these things should be unrelated.

I also added the "slow" marker here which I recently added to ScopeSim in a local branch, and might be in use elsewhere. I put that on some of the integrations tests that, well, take a bit longer. No other plans currently to deal with them differently in all other CI workflows, but might as well exclude them here, where the point is primarily the doctests. All other tests might as well also run, if they don't really impact performance and execution time anyway...