### PR TITLE
Actually update the dependencies in updated_tests.yml

### DIFF
--- a/.github/workflows/updated_tests.yml
+++ b/.github/workflows/updated_tests.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
+          poetry lock
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
 


### PR DESCRIPTION
The goal of the updated tests was to run a project with the latest version of its dependencies, so we would discover breaking changes and/or deprecations early, so we don't "suddenly" have to fix those.

However, we did not actually update the dependencies. This rectifies that.

Note that this still does not actually test any dependency that has a newer 'major' version change.

E.g. see https://github.com/AstarVienna/ScopeSim_Data/actions/runs/11878297751/job/33098809058 , apparently "The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed." Now this is something we can just ignore, as we don't directly use that option ourselves.

In fact, I believe this problem has been fixed in beautifulsoup 4.13.0b2, so apparently this change also does not update to beta releases.