### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/action_updater.yaml
+++ b/.github/workflows/action_updater.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           # This is an organization wide secret.

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -50,17 +50,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.branch }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: "3.11"
 
       - name: Set up Poetry
-        uses: abatilo/actions-poetry@v3
+        uses: abatilo/actions-poetry@v3.0.1
         with:
           poetry-version: "1.8.3"
 

--- a/.github/workflows/docstring_tests.yml
+++ b/.github/workflows/docstring_tests.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.3.0
 
       - name: Set up Poetry
-        uses: abatilo/actions-poetry@v3
+        uses: abatilo/actions-poetry@v3.0.1
         with:
           poetry-version: "1.8.3"
 

--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.labels[0].name != 'no release notes'
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v4.2.2
+    - uses: actions/setup-node@v4.1.0
       with:
         node-version: 20
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,16 +36,16 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
         if: ${{ inputs.poetry }}
-        uses: abatilo/actions-poetry@v3
+        uses: abatilo/actions-poetry@v3.0.1
         with:
           poetry-version: "1.8.3"
 
@@ -79,6 +79,6 @@ jobs:
         run: pytest -m "not webtest" --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5.0.2
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/updated_tests.yml
+++ b/.github/workflows/updated_tests.yml
@@ -26,15 +26,15 @@ jobs:
         python-version: ['3.10', '3.12']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
-        uses: abatilo/actions-poetry@v3
+        uses: abatilo/actions-poetry@v3.0.1
         with:
           poetry-version: "1.8.3"
 

--- a/.github/workflows/webtests.yml
+++ b/.github/workflows/webtests.yml
@@ -28,16 +28,16 @@ jobs:
         python-version: ['3.10', '3.12']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
         if: inputs.poetry
-        uses: abatilo/actions-poetry@v3
+        uses: abatilo/actions-poetry@v3.0.1
         with:
           poetry-version: "1.8.3"
 
@@ -71,6 +71,6 @@ jobs:
         run: pytest -m "webtest" --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[actions/setup-node](https://github.com/actions/setup-node)** published a new release **[v4.1.0](https://github.com/actions/setup-node/releases/tag/v4.1.0)** on 2024-10-24T13:51:16Z
* **[abatilo/actions-poetry](https://github.com/abatilo/actions-poetry)** published a new release **[v3.0.1](https://github.com/abatilo/actions-poetry/releases/tag/v3.0.1)** on 2024-10-27T21:59:51Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.0.2](https://github.com/codecov/codecov-action/releases/tag/v5.0.2)** on 2024-11-15T15:27:48Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.3.0](https://github.com/actions/setup-python/releases/tag/v5.3.0)** on 2024-10-24T14:15:17Z
