### PR TITLE
Ignore gnu.org licenses

### DIFF
--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Check links
       run: |
         # Generate default configuration file if it doesn't exist.
-        if [ ! -f .linkspector.yml ] ; then printf "dirs:\n  - ./\n" > .linkspector.yml ; fi
+        if [ ! -f .linkspector.yml ] ; then printf "dirs:\n  - ./\nignorePatterns:\n  - pattern: '^https://www.gnu.org/licenses.*$'\n" > .linkspector.yml ; fi
         # Run the check.
         linkspector check


### PR DESCRIPTION
Apparently gnu.org is now rate limiting the markdown checker or something like that. But they probably will not cause actual problems, so let's just ignore them.