### PR TITLE
Reverse default order of bump levels

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -11,14 +11,14 @@ on:
         description: Version bump level
         required: true
         options:
-        - major
-        - minor
-        - patch
-        - premajor
-        - preminor
-        - prepatch
         - prerelease
         - "prerelease --next-phase"
+        - prepatch
+        - preminor
+        - premajor
+        - patch
+        - minor
+        - major
 
   workflow_call:
     inputs:


### PR DESCRIPTION
The default bump level used to be "major", which seems a bit dangerous. Already changed it in a few other repos.