### PR TITLE
Default to use poetry on push and PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,23 +44,23 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
-        if: ${{ inputs.poetry }}
+        if: ${{ inputs.poetry }} || github.event_name == 'push' || github.event_name == 'pull_request'
         uses: abatilo/actions-poetry@v3
         with:
           poetry-version: "2.1.3"
 
       - name: Install dependencies with Poetry
-        if: ${{ inputs.poetry }}
+        if: ${{ inputs.poetry }} || github.event_name == 'push' || github.event_name == 'pull_request'
         run: |
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
 
       - name: Run Pytest with Poetry
-        if: ${{ inputs.poetry }}
+        if: ${{ inputs.poetry }} || github.event_name == 'push' || github.event_name == 'pull_request'
         run: poetry run pytest -m "not webtest" --cov --cov-report=xml
 
       - name: Install dependencies without Poetry
-        if: ${{ ! inputs.poetry }}
+        if: ${{ ! inputs.poetry }} && github.event_name != 'push' && github.event_name != 'pull_request'
         run: |
           python -m pip install --upgrade pip
           pip install git+https://github.com/AstarVienna/ScopeSim_Data.git
@@ -75,7 +75,7 @@ jobs:
           pip install pytest pytest-cov
 
       - name: Run Pytest without Poetry
-        if: ${{ ! inputs.poetry }}
+        if: ${{ ! inputs.poetry }} && github.event_name != 'push' && github.event_name != 'pull_request'
         run: pytest -m "not webtest" --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/webtests.yml
+++ b/.github/workflows/webtests.yml
@@ -36,23 +36,23 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up Poetry
-        if: inputs.poetry
+        if: inputs.poetry || github.event_name == 'push' || github.event_name == 'pull_request'
         uses: abatilo/actions-poetry@v3
         with:
           poetry-version: "2.1.3"
 
       - name: Install dependencies with Poetry
-        if: inputs.poetry
+        if: inputs.poetry || github.event_name == 'push' || github.event_name == 'pull_request'
         run: |
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
 
       - name: Run Pytest with Poetry
-        if: inputs.poetry
+        if: inputs.poetry || github.event_name == 'push' || github.event_name == 'pull_request'
         run: poetry run pytest -m "webtest" --cov --cov-report=xml
 
       - name: Install dependencies without Poetry
-        if: ${{ ! inputs.poetry }}
+        if: ${{ ! inputs.poetry }} && github.event_name != 'push' && github.event_name != 'pull_request'
         run: |
           python -m pip install --upgrade pip
           pip install git+https://github.com/AstarVienna/ScopeSim_Data.git
@@ -67,7 +67,7 @@ jobs:
           pip install pytest pytest-cov
 
       - name: Run Pytest without Poetry
-        if: ${{ ! inputs.poetry }}
+        if: ${{ ! inputs.poetry }} && github.event_name != 'push' && github.event_name != 'pull_request'
         run: pytest -m "webtest" --cov --cov-report=xml
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
This is necessary because input parameters only exist for workflow_call and workflow_dispatch, so it's not really possible to set a default value when the action is triggered by a push or pull request. However, since the sample project also uses poetry, those triggers should use it as well. This should solve that.