### PR TITLE
Fix Poetry setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,24 +49,22 @@ jobs:
           USE_POETRY: "${{ (((github.event_name == 'pull_request') || (github.event_name == 'push')) && (inputs.trigger != 'external')) || ((inputs.poetry == true) && ((github.event_name == 'workflow_dispatch') || (inputs.trigger == 'external'))) }}"
         run: echo "USE_POETRY=$USE_POETRY" >> "$GITHUB_OUTPUT"
 
+      - name: Install poetry
+        shell: bash
+        run: pipx install poetry==2.1.4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Set up Poetry
-        if: ${{ steps.decide.outputs.USE_POETRY == 'true' }}
-        shell: bash
-        run: |
-          python3 -m pip install --user pipx
-          python3 -m pipx ensurepath
-          pipx install poetry==2.1.4
 
       - name: Install dependencies with Poetry
         if: ${{ steps.decide.outputs.USE_POETRY == 'true' }}
         run: |
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
+          python -V
+          poetry run python -V
 
       - name: Run Pytest with Poetry
         if: ${{ steps.decide.outputs.USE_POETRY == 'true' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,9 +56,11 @@ jobs:
 
       - name: Set up Poetry
         if: ${{ steps.decide.outputs.USE_POETRY == 'true' }}
-        uses: abatilo/actions-poetry@v3
-        with:
-          poetry-version: "2.1.4"
+        shell: bash
+        run: |
+          python3 -m pip install --user pipx
+          python3 -m pipx ensurepath
+          pipx install poetry==2.1.4
 
       - name: Install dependencies with Poetry
         if: ${{ steps.decide.outputs.USE_POETRY == 'true' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,7 @@ jobs:
         run: echo "USE_POETRY=$USE_POETRY" >> "$GITHUB_OUTPUT"
 
       - name: Install poetry
+        if: ${{ steps.decide.outputs.USE_POETRY == 'true' }}
         shell: bash
         run: pipx install poetry==2.1.4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,8 +63,10 @@ jobs:
         run: |
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
-          python -V
-          poetry run python -V
+
+      - name: Check Python version
+        if: ${{ steps.decide.outputs.USE_POETRY == 'true' }}
+        run: poetry run python -V >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run Pytest with Poetry
         if: ${{ steps.decide.outputs.USE_POETRY == 'true' }}

--- a/.github/workflows/updated_tests.yml
+++ b/.github/workflows/updated_tests.yml
@@ -28,15 +28,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install poetry
+        shell: bash
+        run: pipx install poetry==2.1.4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Set up Poetry
-        uses: abatilo/actions-poetry@v3
-        with:
-          poetry-version: "2.1.4"
 
       - name: Install dependencies
         shell: bash
@@ -44,6 +43,9 @@ jobs:
           poetry lock
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
+
+      - name: Check Python version
+        run: poetry run python -V >> "$GITHUB_STEP_SUMMARY"
 
       - name: Update dependencies
         shell: bash

--- a/.github/workflows/webtests.yml
+++ b/.github/workflows/webtests.yml
@@ -41,22 +41,25 @@ jobs:
           USE_POETRY: "${{ (((github.event_name == 'pull_request') || (github.event_name == 'push')) && (inputs.trigger != 'external')) || ((inputs.poetry == true) && ((github.event_name == 'workflow_dispatch') || (inputs.trigger == 'external'))) }}"
         run: echo "USE_POETRY=$USE_POETRY" >> "$GITHUB_OUTPUT"
 
+      - name: Install poetry
+        if: ${{ steps.decide.outputs.USE_POETRY == 'true' }}
+        shell: bash
+        run: pipx install poetry==2.1.4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Set up Poetry
-        if: ${{ steps.decide.outputs.USE_POETRY == 'true' }}
-        uses: abatilo/actions-poetry@v3
-        with:
-          poetry-version: "2.1.4"
 
       - name: Install dependencies with Poetry
         if: ${{ steps.decide.outputs.USE_POETRY == 'true' }}
         run: |
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
+
+      - name: Check Python version
+        if: ${{ steps.decide.outputs.USE_POETRY == 'true' }}
+        run: poetry run python -V >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run Pytest with Poetry
         if: ${{ steps.decide.outputs.USE_POETRY == 'true' }}


### PR DESCRIPTION
This should now really actually (I hope) solve the recent macOS issues, by installing Poetry first and then the correct Python version, as suggested by the `actions/setup-python` docs. I also now got rid of the `abatilo/actions-poetry`, that project appears abandoned by the (only) author, and after looking at the actual code, it does little more than running `pipx install poetry` anyway.