### PR TITLE
Remove pre-existing Poetry envs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Install dependencies with Poetry
         run: |
+          poetry env remove --all
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
 


### PR DESCRIPTION
Avoid falling back to a Python version pre-installed in the runner. That prevents us from finding out if a Python version doesn't work for a package, because Poetry is "too smart" in this case...