### PR TITLE
Force Poetry to use correct Python version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           poetry install --with test --all-extras
           poetry add git+https://github.com/AstarVienna/ScopeSim_Data.git
+          poetry env use "$(python -c 'import sys; print(sys.executable)')"
 
       - name: Check Python version
         run: poetry run python -V >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Well, trying to run this with an unsupported version (setting the matrix to include 3.9, which the example project here doesn't support) [now fails](https://github.com/AstarVienna/DevOps/actions/runs/17363047022), which wasn't the case for any of my previous attempts. However, if you look carefully at the logs, it still installs with another Python environment (3.12 in this case), but then at least fails when trying to run the tests. So I'm classifying this as a partial success.

The root cause seems to be [a bug in Poetry](https://github.com/orgs/python-poetry/discussions/10523) 😑 