### PR TITLE
Add App bot token to bump workflow

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -50,10 +50,48 @@ jobs:
       bumpmsg: ${{ steps.bumping.outputs.BUMP_MSG }}
 
     steps:
+      - name: Write App private key to file
+        run: |
+          echo "${{ secrets.APP_PRIVATE_KEY }}" > private-key.pem
+
+      - name: Generate JWT
+        id: jwt
+        shell: bash
+        run: |
+          now=$(date +%s)
+          exp=$((now + 600))  # 10 minutes
+          header='{"alg":"RS256","typ":"JWT"}'
+          payload="{\"iat\":$now,\"exp\":$exp,\"iss\":${{ secrets.APP_ID }}}"
+
+          base64url() {
+            openssl base64 -e -A | tr '+/' '-_' | tr -d '='
+          }
+
+          jwt_header=$(echo -n "$header" | base64url)
+          jwt_payload=$(echo -n "$payload" | base64url)
+
+          jwt_unsigned="${jwt_header}.${jwt_payload}"
+          jwt_signature=$(echo -n "$jwt_unsigned" | openssl dgst -sha256 -sign private-key.pem | base64url)
+
+          echo "jwt_token=${jwt_unsigned}.${jwt_signature}" >> $GITHUB_OUTPUT
+
+      - name: Request Installation Access Token
+        id: auth
+        shell: bash
+        run: |
+          token=$(curl -s -X POST \
+            -H "Authorization: Bearer ${{ steps.jwt.outputs.jwt_token }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/app/installations/${{ secrets.APP_INSTALLATION_ID }}/access_tokens |
+            jq -r .token)
+
+          echo "token=$token" >> $GITHUB_OUTPUT
+
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branch }}
+          token: ${{ steps.auth.outputs.token }}
 
       - name: Install poetry
         shell: bash
@@ -85,8 +123,8 @@ jobs:
         env:
           BUMP_MSG: ${{ steps.bumping.outputs.BUMP_MSG }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "AstarVienna Bot"
+          git config user.email "astar.astro@univie.ac.at"
           git commit -am "$BUMP_MSG"
           git push
           echo "## $BUMP_MSG" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This allows us to keep a "require PR for changes" rule on our main branches while still being able to use the auto-bump workflow as part of the release workflow (and potentially others).

Tested (arduously) in astar-utils, works there, now just have to make sure it works cross-repo... (as usual, can't easily do that without merging.....)