### PR TITLE
Use sparse matrix for macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         experimental: [false]
-        # include:
+        include:
+          - os: macos-latest
+            python-version: '3.10'
+          - os: macos-latest
+            python-version: '3.14'
         #   - os: ubuntu-latest
         #     python-version: '3.15'
         #     experimental: true


### PR DESCRIPTION
Testing on macOS drives up the cost of running these things unproportionally compared to the user base on that OS. While GitHub doesn't actually charge us anything _yet_, I think it's reasonable to reduce our usage here. I really don't expect any surprises if we keep testing the highest and lowest officially supported versions on macOS, considering that we'd still test all in-between versions on Ubuntu and Windows...