### PR TITLE
Allow overriding Python version matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,18 @@ on:
   # Allow this workflow to be called from other repositories.
   workflow_call:
     inputs:
-      poetry:
-        type: boolean
-        description: "Deprecated, will now always use Poetry."
+      python-versions:
         required: false
-        default: true
+        type: string
+        default: "['3.10', '3.11', '3.12', '3.13', '3.14']"
+      python-min:
+        required: false
+        type: string
+        default: '3.10'
+      python-max:
+        required: false
+        type: string
+        default: '3.14'
 
 jobs:
   run-tests:
@@ -27,13 +34,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ${{ fromJSON(inputs.python-versions) }}
         experimental: [false]
         include:
           - os: macos-latest
-            python-version: '3.10'
+            python-version: ${{ inputs.python-min }}
           - os: macos-latest
-            python-version: '3.14'
+            python-version: ${{ inputs.python-max }}
         #   - os: ubuntu-latest
         #     python-version: '3.15'
         #     experimental: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,8 @@ on:
       python-versions:
         required: false
         type: string
-        default: "['3.10', '3.11', '3.12', '3.13', '3.14']"
+        # IMPORTANT: When updating these, also update below!!
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       python-min:
         required: false
         type: string
@@ -34,13 +35,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ${{ fromJSON(inputs.python-versions) }}
+        # IMPORTANT: When updating these, also update above!!
+        python-version: ${{ fromJSON(inputs.python-versions || '["3.10", "3.11", "3.12", "3.13", "3.14"]') }}
         experimental: [false]
         include:
           - os: macos-latest
-            python-version: ${{ inputs.python-min }}
+            python-version: ${{ inputs.python-min || '3.10' }}
           - os: macos-latest
-            python-version: ${{ inputs.python-max }}
+            python-version: ${{ inputs.python-max || '3.14' }}
         #   - os: ubuntu-latest
         #     python-version: '3.15'
         #     experimental: true

--- a/.github/workflows/updated_tests.yml
+++ b/.github/workflows/updated_tests.yml
@@ -12,8 +12,12 @@ on:
 
   # Allow this workflow to be called from other repositories.
   workflow_call:
-
-# This workflow needs Poetry, so no flag is included.
+    inputs:
+      python-versions:
+        required: false
+        type: string
+        # IMPORTANT: When updating these, also update below!!
+        default: '["3.10", "3.14"]'
 
 jobs:
   run-tests:
@@ -23,7 +27,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.14']
+        # IMPORTANT: When updating these, also update above!!
+        python-version: ${{ fromJSON(inputs.python-versions || '["3.10", "3.14"]') }}
         experimental: [false]
         # include:
         #   - os: ubuntu-latest

--- a/.github/workflows/webtests.yml
+++ b/.github/workflows/webtests.yml
@@ -6,10 +6,11 @@ on:
   # Allow this workflow to be called from other repositories.
   workflow_call:
     inputs:
-      poetry:
-        type: boolean
-        description: "Deprecated, will now always use Poetry."
+      python-versions:
         required: false
+        type: string
+        # IMPORTANT: When updating these, also update below!!
+        default: '["3.10", "3.14"]'
 
 jobs:
   run-tests:
@@ -20,7 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.14']
+        # IMPORTANT: When updating these, also update above!!
+        python-version: ${{ fromJSON(inputs.python-versions || '["3.10", "3.14"]') }}
         experimental: [false]
         # include:
         #   - os: ubuntu-latest


### PR DESCRIPTION
Useful when updating supported Python versions for different packages in the ecosystem one at a time...

Annoyingly, the defaults now have to be stored in two places, because of different contexts when running on push/PR here vs. when called from elsewhere. Alternative solution would be to use these strictly as _called_ workflows, and have another workflow that acts as the caller on push/PR, much like these are called from elsewhere anyway. I think that's also how we solved a similar issue in the IRDB. But we can always come back and do that, it wouldn't change the outside call signature...