### PR TITLE
Run markdown link check only monthly

### DIFF
--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -4,8 +4,8 @@ name: Check Markdown links
 on:
   # push:
   schedule:
-    # Run every day at 5:00 UTC
-    - cron: "0 5 * * 1"
+    # Runs at 08:00 UTC, on day 1 of each month.
+    - cron: "0 8 1 * *"
 
   # Allow this workflow to be called from other repositories.
   workflow_call:


### PR DESCRIPTION
As suggested in https://github.com/AstarVienna/DevOps/pull/92#issuecomment-4327326327.

Switched to 0800 h because re-running a bit later usually solves the failures, so maybe the server is extra busy at 0500 h.